### PR TITLE
feat: bump schedule-x deps to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,73 +4,63 @@ All notable changes to this project will be documented in this file. See [Conven
 
 ## [1.63.1](https://github.com/schedule-x/react/compare/v1.63.0...v1.63.1) (2024-09-13)
 
-
 ### Bug Fixes
 
-* update schedule-x monorepo packages to v1.63.1 ([#185](https://github.com/schedule-x/react/issues/185)) ([596777f](https://github.com/schedule-x/react/commit/596777f05c1b71624a3bb758821a76578853951c))
+- update schedule-x monorepo packages to v1.63.1 ([#185](https://github.com/schedule-x/react/issues/185)) ([596777f](https://github.com/schedule-x/react/commit/596777f05c1b71624a3bb758821a76578853951c))
 
 # [1.63.0](https://github.com/schedule-x/react/compare/v1.62.0...v1.63.0) (2024-09-11)
 
-
 ### Features
 
-* update schedule-x monorepo packages to v1.63.0 ([#181](https://github.com/schedule-x/react/issues/181)) ([bc3d855](https://github.com/schedule-x/react/commit/bc3d855bde2706b491f1376eee145325b9fd3819))
+- update schedule-x monorepo packages to v1.63.0 ([#181](https://github.com/schedule-x/react/issues/181)) ([bc3d855](https://github.com/schedule-x/react/commit/bc3d855bde2706b491f1376eee145325b9fd3819))
 
 # [1.62.0](https://github.com/schedule-x/react/compare/v1.61.0...v1.62.0) (2024-09-07)
 
-
 ### Features
 
-* custom header component ([#182](https://github.com/schedule-x/react/issues/182)) ([a5f5afe](https://github.com/schedule-x/react/commit/a5f5afea56b713158668ee70ed8146669f548f00))
+- custom header component ([#182](https://github.com/schedule-x/react/issues/182)) ([a5f5afe](https://github.com/schedule-x/react/commit/a5f5afea56b713158668ee70ed8146669f548f00))
 
 # [1.61.0](https://github.com/schedule-x/react/compare/v1.60.0...v1.61.0) (2024-09-07)
 
-
 ### Features
 
-* update schedule-x monorepo packages to v1.61.0 ([#179](https://github.com/schedule-x/react/issues/179)) ([32fde3a](https://github.com/schedule-x/react/commit/32fde3af2cb780e0760b8edf74a228b068c922b9))
+- update schedule-x monorepo packages to v1.61.0 ([#179](https://github.com/schedule-x/react/issues/179)) ([32fde3a](https://github.com/schedule-x/react/commit/32fde3af2cb780e0760b8edf74a228b068c922b9))
 
 # [1.60.0](https://github.com/schedule-x/react/compare/v1.59.1...v1.60.0) (2024-09-04)
 
-
 ### Features
 
-* update schedule-x monorepo packages to v1.61.0 ([#178](https://github.com/schedule-x/react/issues/178)) ([bf5a6ed](https://github.com/schedule-x/react/commit/bf5a6ed83ea8252da429760f9524b3628f584631))
+- update schedule-x monorepo packages to v1.61.0 ([#178](https://github.com/schedule-x/react/issues/178)) ([bf5a6ed](https://github.com/schedule-x/react/commit/bf5a6ed83ea8252da429760f9524b3628f584631))
 
 ## [1.59.1](https://github.com/schedule-x/react/compare/v1.59.0...v1.59.1) (2024-09-03)
 
-
 ### Bug Fixes
 
-* update schedule-x monorepo packages to v1.60.1 ([#176](https://github.com/schedule-x/react/issues/176)) ([2f4e68e](https://github.com/schedule-x/react/commit/2f4e68e1c8bfb4fee6501d94462c3b62b132d022))
+- update schedule-x monorepo packages to v1.60.1 ([#176](https://github.com/schedule-x/react/issues/176)) ([2f4e68e](https://github.com/schedule-x/react/commit/2f4e68e1c8bfb4fee6501d94462c3b62b132d022))
 
 # [1.59.0](https://github.com/schedule-x/react/compare/v1.58.3...v1.59.0) (2024-08-31)
 
-
 ### Features
 
-* update schedule-x monorepo packages to v1.60.0 ([#174](https://github.com/schedule-x/react/issues/174)) ([27d9761](https://github.com/schedule-x/react/commit/27d9761489f2d75d22480db4b9d37f468668e7d0))
+- update schedule-x monorepo packages to v1.60.0 ([#174](https://github.com/schedule-x/react/issues/174)) ([27d9761](https://github.com/schedule-x/react/commit/27d9761489f2d75d22480db4b9d37f468668e7d0))
 
 ## [1.58.3](https://github.com/schedule-x/react/compare/v1.58.2...v1.58.3) (2024-08-28)
 
-
 ### Bug Fixes
 
-* update schedule-x monorepo packages to v1.59.2 ([#173](https://github.com/schedule-x/react/issues/173)) ([8a688dc](https://github.com/schedule-x/react/commit/8a688dc05cdc58d9bd12a5df5993dd332bd99f10))
+- update schedule-x monorepo packages to v1.59.2 ([#173](https://github.com/schedule-x/react/issues/173)) ([8a688dc](https://github.com/schedule-x/react/commit/8a688dc05cdc58d9bd12a5df5993dd332bd99f10))
 
 ## [1.58.2](https://github.com/schedule-x/react/compare/v1.58.1...v1.58.2) (2024-08-26)
 
-
 ### Bug Fixes
 
-* update schedule-x monorepo packages to v1.59.1 ([#172](https://github.com/schedule-x/react/issues/172)) ([8440fda](https://github.com/schedule-x/react/commit/8440fda01b30934dc13c4cf29e91275094ed8892))
+- update schedule-x monorepo packages to v1.59.1 ([#172](https://github.com/schedule-x/react/issues/172)) ([8440fda](https://github.com/schedule-x/react/commit/8440fda01b30934dc13c4cf29e91275094ed8892))
 
 ## [1.58.1](https://github.com/schedule-x/react/compare/v1.58.0...v1.58.1) (2024-08-25)
 
-
 ### Bug Fixes
 
-* type declarations ([#171](https://github.com/schedule-x/react/issues/171)) ([3331e76](https://github.com/schedule-x/react/commit/3331e76a1657b535ee31986350e5b2d8b5fcbc30))
+- type declarations ([#171](https://github.com/schedule-x/react/issues/171)) ([3331e76](https://github.com/schedule-x/react/commit/3331e76a1657b535ee31986350e5b2d8b5fcbc30))
 
 # [1.58.0](https://github.com/schedule-x/react/compare/v1.57.1...v1.58.0) (2024-08-24)
 

--- a/cypress/pages/001-smoke/001-smoke.tsx
+++ b/cypress/pages/001-smoke/001-smoke.tsx
@@ -5,7 +5,7 @@ import '@fontsource/open-sans/700.css'
 import '@fontsource/open-sans/700-italic.css'
 import ReactDOM from 'react-dom/client'
 import React from 'react'
-import { Calendar, useCalendarApp } from '../../..'
+import { ScheduleXCalendar, useCalendarApp } from '../../..'
 import {
   viewDay,
   viewMonthAgenda,
@@ -34,7 +34,7 @@ function App() {
   return (
     <>
       <div className="schedule-x-calendar">
-        <Calendar calendarApp={calendarApp} />
+        <ScheduleXCalendar calendarApp={calendarApp} />
       </div>
     </>
   )

--- a/development/App.tsx
+++ b/development/App.tsx
@@ -57,7 +57,7 @@ function App() {
             monthAgendaEvent: CustomDateGridEvent,
             monthGridEvent: CustomDateGridEvent,
             eventModal: CustomEventModal,
-            headerContent: () => (<>Custom header</>),
+            headerContent: () => <>Custom header</>,
           }}
         />
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,12 @@
         "@rollup/plugin-commonjs": "^26.0.0",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-typescript": "^11.1.5",
-        "@schedule-x/drag-and-drop": "^1.62.0",
-        "@schedule-x/e2e-testing": "^1.62.0",
-        "@schedule-x/eslint-config": "^1.62.0",
-        "@schedule-x/event-modal": "^1.62.0",
-        "@schedule-x/prettier-config": "^1.62.0",
-        "@schedule-x/theme-default": "^1.62.0",
+        "@schedule-x/drag-and-drop": "^2.0.0",
+        "@schedule-x/e2e-testing": "^2.0.0",
+        "@schedule-x/eslint-config": "^2.0.0",
+        "@schedule-x/event-modal": "^2.0.0",
+        "@schedule-x/prettier-config": "^2.0.0",
+        "@schedule-x/theme-default": "^2.0.0",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "@types/react": "^18.2.43",
@@ -40,7 +40,7 @@
         "vite": "^5.0.8"
       },
       "peerDependencies": {
-        "@schedule-x/calendar": "^1.62.0",
+        "@schedule-x/calendar": "^2.0.0",
         "react": "^16.7.0 || ^17 || ^18",
         "react-dom": "^16.7.0 || ^17 || ^18"
       }
@@ -1744,9 +1744,9 @@
       ]
     },
     "node_modules/@schedule-x/calendar": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@schedule-x/calendar/-/calendar-1.62.0.tgz",
-      "integrity": "sha512-An5k4iMx0woKMD42glEGSwJLj67gwqtro+2KqqzXOIPvBzRMtcpkHNvANEQtvbdx5ZtjsbzI98e/kHp+YQL96w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@schedule-x/calendar/-/calendar-2.0.0.tgz",
+      "integrity": "sha512-n2DBAt+thtpUIKcCU6kP4Vt5GTbmnWwXl4VU+c7TwRrmnScCR0b5jen9ejYdZOgQol0KPSK1DC2mrSxYRaC2Bg==",
       "peer": true,
       "peerDependencies": {
         "@preact/signals": "^1.1.5",
@@ -1754,53 +1754,47 @@
       }
     },
     "node_modules/@schedule-x/drag-and-drop": {
-      "version": "1.63.1",
-      "resolved": "https://registry.npmjs.org/@schedule-x/drag-and-drop/-/drag-and-drop-1.63.1.tgz",
-      "integrity": "sha512-N12pIyMdnc+WIAv4lVcAbDgAix0xMgxK6d3TjzDt50Q8sJMWwFSSan/Uqk60LyQwVlhoAuzTVt+wmd87RELrWA==",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@schedule-x/drag-and-drop/-/drag-and-drop-2.0.0.tgz",
+      "integrity": "sha512-UFSlw4oH1QaAx+Ti6i+cQSXmspgPgVDdkKxODQYrv6AyKMjg9cZhJ4QUkMmhTXWNBDXUN9YvSxtNQ1AEdhTN3g==",
+      "dev": true
     },
     "node_modules/@schedule-x/e2e-testing": {
-      "version": "1.63.1",
-      "resolved": "https://registry.npmjs.org/@schedule-x/e2e-testing/-/e2e-testing-1.63.1.tgz",
-      "integrity": "sha512-Ew9bKMvYf9lBVKRQE+5WqxxpFmFue996G0rsXz5tJ80eNTCWYh+PWCSik5xY7FHpeJ+FtweC4CcUL/fWqJOYTg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@schedule-x/e2e-testing/-/e2e-testing-2.0.0.tgz",
+      "integrity": "sha512-P6+a5JYxTauReKVT7vZzgz37615hA3xbi2SeZ4Jc4zli4LmerkWuWKX6QhCL0WsjwfgKWd69aN/8/trIXsdZ/g==",
       "dev": true
     },
     "node_modules/@schedule-x/eslint-config": {
-      "version": "1.63.1",
-      "resolved": "https://registry.npmjs.org/@schedule-x/eslint-config/-/eslint-config-1.63.1.tgz",
-      "integrity": "sha512-w7TDJEna2W+kHvBRcDGWMpQMcyVYFHNVdYKWlIiCtUsimL3STgYkyHwnpP0Ho2p+HUqwiPuw1NOW6tB8yyia9A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@schedule-x/eslint-config/-/eslint-config-2.0.0.tgz",
+      "integrity": "sha512-k12iXA+j/lhOG7bwkI4rHLY9yjwm2qmhPbzY2/zm4K+RNJ+XC3PWypCIXYVPpl5bGrQt1UR9e7IGKF/mwFeX1g==",
       "dev": true
     },
     "node_modules/@schedule-x/event-modal": {
-      "version": "1.63.1",
-      "resolved": "https://registry.npmjs.org/@schedule-x/event-modal/-/event-modal-1.63.1.tgz",
-      "integrity": "sha512-RIcsMtLEYkPM6N8dvC9T1OBQBt8IetH6mhJ7//TeNppgI81dgd3U6zz03hhpeTuEZ73vXIQM5RYe4uWZuXvQ6Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@schedule-x/event-modal/-/event-modal-2.0.0.tgz",
+      "integrity": "sha512-adNXkS+lm9cS03/AraEChdE+W7bX1PRXVYxIudft2Sorh+VTtdxQ98Px+4B+7SuFLPAjwKgtq6zpq5mIE6n9Pw==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "@preact/signals": "^1.1.5",
         "preact": "^10.19.2"
       }
     },
     "node_modules/@schedule-x/prettier-config": {
-      "version": "1.63.1",
-      "resolved": "https://registry.npmjs.org/@schedule-x/prettier-config/-/prettier-config-1.63.1.tgz",
-      "integrity": "sha512-gssyJDNUdgVoZBqf3NUXdQjClKlg7g2tTOAnPXUP/IhK1bmVJeS3pORTiN/7MFt0ZGYlpxm4DQy0TIlwgZJgHw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@schedule-x/prettier-config/-/prettier-config-2.0.0.tgz",
+      "integrity": "sha512-9U9IbcC5xy80lzCPDaGsONb+2IvDgHEi4hcq1SLF8DPC5rcOFWBx2Brgyf2nxcUnzSP8TS7V7kRcuUA/UloVgQ==",
       "dev": true,
       "peerDependencies": {
         "prettier": "^3.0.0"
       }
     },
     "node_modules/@schedule-x/theme-default": {
-      "version": "1.63.1",
-      "resolved": "https://registry.npmjs.org/@schedule-x/theme-default/-/theme-default-1.63.1.tgz",
-      "integrity": "sha512-uV54HQUggVl7yfz/WSId9RUxzoYFYdPE+PKKJ8ZPLNOhP/E4MvK+o3rFx1OmhzWSSyPMOv9M4jgjBKfH4Hk0vg==",
-      "dev": true,
-      "license": "MIT",
-      "workspaces": [
-        "packages/*"
-      ]
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@schedule-x/theme-default/-/theme-default-2.0.0.tgz",
+      "integrity": "sha512-PZ3OuG7v1K/5oLlkgbtAmtqt9R71iT21+Zt4sXb9DfnXrCaQPvLCWbcuXSXcofrs7WYssWJGN/50iU51aE5yiw==",
+      "dev": true
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build:publish": "npm run build && npm publish"
   },
   "peerDependencies": {
-    "@schedule-x/calendar": "^1.62.0",
+    "@schedule-x/calendar": "^2.0.0",
     "react": "^16.7.0 || ^17 || ^18",
     "react-dom": "^16.7.0 || ^17 || ^18"
   },
@@ -40,12 +40,12 @@
     "@rollup/plugin-commonjs": "^26.0.0",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-typescript": "^11.1.5",
-    "@schedule-x/drag-and-drop": "^1.62.0",
-    "@schedule-x/e2e-testing": "^1.62.0",
-    "@schedule-x/eslint-config": "^1.62.0",
-    "@schedule-x/event-modal": "^1.62.0",
-    "@schedule-x/prettier-config": "^1.62.0",
-    "@schedule-x/theme-default": "^1.62.0",
+    "@schedule-x/drag-and-drop": "^2.0.0",
+    "@schedule-x/e2e-testing": "^2.0.0",
+    "@schedule-x/eslint-config": "^2.0.0",
+    "@schedule-x/event-modal": "^2.0.0",
+    "@schedule-x/prettier-config": "^2.0.0",
+    "@schedule-x/theme-default": "^2.0.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@types/react": "^18.2.43",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,2 @@
-// @deprecated. To be removed in v1.0.0
-export { ScheduleXCalendar as Calendar } from './schedule-x-calendar.tsx'
-
 export { ScheduleXCalendar } from './schedule-x-calendar.tsx'
 export { useCalendarApp, useNextCalendarApp } from './use-calendar-app.tsx'


### PR DESCRIPTION
BREAKING CHANGE: v1 plugins do not work with v2
BREAKING CHANGE: Calendar alias component deprecated, use ScheduleXCalendar instead